### PR TITLE
Update KerbalAtomics.version

### DIFF
--- a/GameData/KerbalAtomics/Versioning/KerbalAtomics.version
+++ b/GameData/KerbalAtomics/Versioning/KerbalAtomics.version
@@ -1,6 +1,6 @@
 {
     "NAME":"KerbalAtomics",
-    "URL":"https://github.com/ChrisAdderley/KerbalAtomics/blob/master/GameData/KerbalAtomics/Versioning/KerbalAtomics.version",
+    "URL":"https://raw.githubusercontent.com/ChrisAdderley/KerbalAtomics/master/GameData/KerbalAtomics/Versioning/KerbalAtomics.version",
     "DOWNLOAD":"http://forum.kerbalspaceprogram.com/threads/117766",
     "VERSION":
     {


### PR DESCRIPTION
`URL` has to point to the raw GitHub content rather than the HTML page to work. Not sure if you're working off of this repository but presumably you'll want to also update the `DOWNLOAD` URL and the versioning information.
