### PR TITLE
Added compatibility for Ven's Stock Revamp

### DIFF
--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsVen
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsVen
@@ -1,0 +1,39 @@
+// MM Configs for changing various NTRs to use LqdHydrogen
+
+// NT-5R "Shiba" Rocket Motor (Ven's Stock Revamp)
+@PART[PoodleM] 
+{
+  @MODULE[ModuleEngines]   {
+	!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 650
+			key = 1 330
+			key = 4 0.001
+		}
+     @PROPELLANT[LiquidFuel] 
+     {
+        @name = LqdHydrogen 
+        @ratio = 1.0  
+     }
+  }
+}
+
+// RE-N4 "Nova" Atomic Rocket Motor (Ven's Stock Revamp)
+@PART[size2nuclearEngine] 
+{
+  @MODULE[ModuleEngines]   {
+	!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 900
+			key = 1 350
+			key = 4 0.001
+		}
+     @PROPELLANT[LiquidFuel] 
+     {
+        @name = LqdHydrogen 
+        @ratio = 1.0  
+     }
+  }
+}


### PR DESCRIPTION
I added a compatibility file for the nuclear engines in Ven's Stock Revamp. I notice you change the ISP values, wasn't sure of the formula used, so I tried to give them values in line with the other compatibility configs.