### PR TITLE
LV-N multi-mode fixes

### DIFF
--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
@@ -99,18 +99,25 @@
 		preferMultiMode = true
 	}
 
+	// The LH2NTRsDynamic patch should have changed this engine to burn LH2
+	// already, but apply some part-specific tweaks.
 	@MODULE[ModuleEngines]   {
 		@name = ModuleEnginesFX
 		engineID = LH2
 		runningEffectName = fx-sc-lh2-core
 		powerEffectName = fx-sc-lh2-plume
 		@fxOffset = 0, 0, 1.5
+
+		// Redundant since LH2NTRsDynamic does this already, but do it
+		// again as a fail-safe in case that patch is removed.
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = LqdHydrogen
 			@ratio = 1.0
 		}
 
+		// Part-specific Isp values, overriding the generic adjustment
+		// done by LH2NTRsDynamic.
 		!atmosphereCurve {}
 		atmosphereCurve
 		{
@@ -121,6 +128,7 @@
 		}
 	}
 
+	// Copy the LH2 engine module to make an LF-burning alternative mode.
 	$MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]
 	{
 		@engineID = LF

--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
@@ -94,6 +94,11 @@
 		secondaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LH2
 	}
 
+	@MODULE[ModuleAlternator]
+	{
+		preferMultiMode = true
+	}
+
 	@MODULE[ModuleEngines]   {
 		@name = ModuleEnginesFX
 		engineID = LH2

--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
@@ -85,23 +85,30 @@
 
 	@MODULE[ModuleEngines]   {
 		@name = ModuleEnginesFX
-		engineID = LF
+		engineID = LH2
 		runningEffectName = fx-sc-lh2-core
 		powerEffectName = fx-sc-lh2-plume
 		fxOffset = 0, 0, 1.5
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.0
+		}
+
 		!atmosphereCurve {}
 		atmosphereCurve
 		{
-			key = 0 600
-			key = 1 185
-			key = 2 0.001
+			key = 0 900
+			key = 1 400
+			key = 2 50
+			key = 10 1
 		}
 	}
 
 	MODULE
 	{
 		name = ModuleEnginesFX
-		engineID = LH2
+		engineID = LF
 		thrustVectorTransformName = thrustTransform
 		exhaustDamage = True
 		runningEffectName = fx-sc-lh2-core
@@ -115,15 +122,15 @@
 		exhaustDamageDistanceOffset = 1.86
 		PROPELLANT
 		{
-			name = LiquidHydrogen
-			ratio = 1.0
+			name = LiquidFuel
+			ratio = 0.9
+			DrawGauge = True
 		}
 		atmosphereCurve
 		{
-			key = 0 900
-			key = 1 400
-			key = 2 50
-			key = 10 1
+			key = 0 600
+			key = 1 185
+			key = 2 0.001
 		}
 	}
 }

--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
@@ -73,6 +73,17 @@
 				speed = 1.0 1.0
 			}
 		}
+		fx-sc-lf-core
+		{
+			// Copy from the corresponding LH2 effect.
+			#../fx-sc-lh2-core/AUDIO {}
+			#../fx-sc-lh2-core/MODEL_MULTI_PARTICLE {}
+		}
+		fx-sc-lf-plume
+		{
+			// Copy from the corresponding LH2 effect.
+			#../fx-sc-lh2-plume/MODEL_MULTI_PARTICLE {}
+		}
 	}
 	MODULE
 	{
@@ -111,8 +122,8 @@
 		engineID = LF
 		thrustVectorTransformName = thrustTransform
 		exhaustDamage = True
-		runningEffectName = fx-sc-lh2-core
-		powerEffectName = fx-sc-lh2-plume
+		runningEffectName = fx-sc-lf-core
+		powerEffectName = fx-sc-lf-plume
 		ignitionThreshold = 0.1
 		minThrust = 0
 		maxThrust = 60

--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
@@ -116,27 +116,18 @@
 		}
 	}
 
-	MODULE
+	$MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]
 	{
-		name = ModuleEnginesFX
-		engineID = LF
-		thrustVectorTransformName = thrustTransform
-		exhaustDamage = True
-		runningEffectName = fx-sc-lf-core
-		powerEffectName = fx-sc-lf-plume
-		ignitionThreshold = 0.1
-		minThrust = 0
-		maxThrust = 60
-		heatProduction = 250
-		fxOffset = 0, 0, 1.5
-		EngineType = Nuclear
-		exhaustDamageDistanceOffset = 1.86
-		PROPELLANT
+		@engineID = LF
+		@runningEffectName = fx-sc-lf-core
+		@powerEffectName = fx-sc-lf-plume
+		@PROPELLANT[LqdHydrogen]
 		{
-			name = LiquidFuel
-			ratio = 0.9
-			DrawGauge = True
+			@name = LiquidFuel
+			@ratio = 0.9
 		}
+
+		!atmosphereCurve {}
 		atmosphereCurve
 		{
 			key = 0 600

--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
@@ -99,7 +99,7 @@
 		engineID = LH2
 		runningEffectName = fx-sc-lh2-core
 		powerEffectName = fx-sc-lh2-plume
-		fxOffset = 0, 0, 1.5
+		@fxOffset = 0, 0, 1.5
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = LqdHydrogen
@@ -128,7 +128,7 @@
 		minThrust = 0
 		maxThrust = 60
 		heatProduction = 250
-		fxOffset = 0, 0, 1.6
+		fxOffset = 0, 0, 1.5
 		EngineType = Nuclear
 		exhaustDamageDistanceOffset = 1.86
 		PROPELLANT


### PR DESCRIPTION
This is a set of fixes for some problems in the LV-N patch that were identified in a [forum post by JadeOfMaar](https://forum.kerbalspaceprogram.com/index.php?/topic/130503-131-kerbal-atomics-fancy-nuclear-engines-october-17/&do=findComment&comment=3209119):
* [No sound or flame in LH2 mode](https://forum.kerbalspaceprogram.com/index.php?/topic/130503-131-kerbal-atomics-fancy-nuclear-engines-october-17/&do=findComment&comment=3199211).
* Alternator didn't work in LF mode
* Possible slight mis-positioning of exhaust plume (though I don't see a difference)