### PR TITLE
Exclude multi-mode engines from generic LF→LH2 NTR patch

### DIFF
--- a/GameData/KerbalAtomics/Patches/NTR/LH2NTRsDynamic.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/LH2NTRsDynamic.cfg
@@ -1,7 +1,7 @@
 // MM Configs for changing various NTRs to use LqdHydrogen
 // Dynamic patch by TheToric
 
-@PART[*]:HAS[@MODULE[ModuleEnginesFX]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer],!PROPELLANT[IntakeAir]]]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
+@PART[*]:HAS[@MODULE[ModuleEnginesFX]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer],!PROPELLANT[IntakeAir]],!MODULE[MultiModeEngine]]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
 {
     @mass *= 0.75
        @MODULE[ModuleEnginesFX]
@@ -17,7 +17,7 @@
         }
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngines]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer],!PROPELLANT[IntakeAir]]]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
+@PART[*]:HAS[@MODULE[ModuleEngines]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer],!PROPELLANT[IntakeAir]],!MODULE[MultiModeEngine]]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
 {
     @mass *= 0.75
        @MODULE[ModuleEngines]


### PR DESCRIPTION
The `LH2NTRsDynamic` patch looks for engines that seem like LiquidFuel-burning NTRs and changes them to burn LqdHydrogen instead, but it assumes that the LiquidFuel-burning engine module is the part's *only* engine module.  When applied to a multi-mode engine, it can end up patching the "wrong" engine module (not the LF one), or it might change an LF/LH2 multi-mode engine to burn LH2 in both modes.

To avoid those problems, it's best to avoid patching multi-mode engines.  Such parts are specialized enough that they ought to have part-specific patches (if needed) rather than a one-size-fits-all.