### PR TITLE
Spacetux engine patches

### DIFF
--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsClusters.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsClusters.cfg
@@ -1,0 +1,153 @@
+// MM Configs for changing various NTRs to use LiquidHydrogen
+
+// LV-2N and LV-4N clusters, which are similar to the stock LV-N and should
+// remain similar after these patches are applied.  Any changes in the
+// hydrogenNTRsSQUAD patch should be made here too.
+@PART[lv2n|lv4n]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
+{
+	@mass *= 0.75  // Same ratio as the patch for the stock LV-N
+
+	EFFECTS
+	{
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			PREFAB_PARTICLE
+			{
+				prefabName = fx_exhaustSparks_flameout_2
+				transformName = thrustTransform
+				oneShot = true
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		fx-sc-lh2-core
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_rocket_hard
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = KerbalAtomics/FX/fx-sc-lh2-125-core
+				transformName = thrustTransform
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
+		}
+		fx-sc-lh2-plume
+		{
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = KerbalAtomics/FX/fx-sc-lh2-125-plume
+				transformName = thrustTransform
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
+		}
+		fx-sc-lf-core
+		{
+			// Copy from the corresponding LH2 effect.
+			#../fx-sc-lh2-core/AUDIO {}
+			#../fx-sc-lh2-core/MODEL_MULTI_PARTICLE {}
+		}
+		fx-sc-lf-plume
+		{
+			// Copy from the corresponding LH2 effect.
+			#../fx-sc-lh2-plume/MODEL_MULTI_PARTICLE {}
+		}
+	}
+	MODULE
+	{
+		name = MultiModeEngine
+		primaryEngineID = LF
+		secondaryEngineID = LH2
+		primaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LF
+		secondaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LH2
+	}
+
+	@MODULE[ModuleAlternator]
+	{
+		preferMultiMode = true
+	}
+
+	// The LH2NTRsDynamic patch should have changed this engine to burn LH2
+	// already, but apply some part-specific tweaks.
+	@MODULE[ModuleEngines] {
+		@name = ModuleEnginesFX
+		@engineID = LH2
+		runningEffectName = fx-sc-lh2-core
+		powerEffectName = fx-sc-lh2-plume
+		fxOffset = 0, 0, 1.5
+
+		// Redundant since LH2NTRsDynamic does this already, but do it
+		// again as a fail-safe in case that patch is removed.
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.0
+		}
+
+		// Part-specific Isp values, overriding the generic adjustment
+		// done by LH2NTRsDynamic.
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 900
+			key = 1 400
+			key = 2 50
+			key = 10 1
+		}
+	}
+
+	// Copy the LH2 engine module to make an LF-burning alternative mode.
+	$MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]
+	{
+		@engineID = LF
+		@runningEffectName = fx-sc-lf-core
+		@powerEffectName = fx-sc-lf-plume
+		@PROPELLANT[LqdHydrogen]
+		{
+			@name = LiquidFuel
+			@ratio = 0.9
+		}
+
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 600
+			key = 1 185
+			key = 2 0.001
+		}
+	}
+}

--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsTaurus.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsTaurus.cfg
@@ -1,0 +1,48 @@
+// MM Configs for changing various NTRs to use LqdHydrogen
+
+// Taurus Nuke
+// This part has two engine modules: one for the big nuclear engine, and one for
+// the four small radial nozzles that may be either nuclear or chemical
+// (depending on other patches).  The big nuclear engine is handled well enough
+// by the LH2NTRsDynamic patch, and if the small radial nozzles are configured
+// as nuclear, it handles those well enough too.  But if the radial nozzles are
+// configured as chemical, the LH2NTRsDynamic patch doesn't touch them, so they
+// still burn LF while the nuclear engine uses LH2.  This patch changes the
+// chemical radial nozzles to burn LH2 instead, so the spacecraft doesn't have
+// to carry both kinds of fuel.
+@PART[taurusNuclearEngine]:HAS[@MODULE[ModuleEnginesFX]:HAS[#runningEffectName[gimbal_Running],@PROPELLANT[Oxidizer]]]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
+{
+	// The LH2NTRsDynamic patch multiplies a nuclear engine's mass by 0.75, but
+	// that's assuming the entire part is the nuclear engine.  In this case, the
+	// four radial nozzles are not.  We'll say they're 0.2 tons each, since they
+	// look similar to the stock 24-77 "Twitch" engine (0.09 tons) but are
+	// roughly twice as big, so 0.8 tons of the part's mass should be excluded
+	// from the 0.75x NTR mass adjustment.
+	@mass /= 0.75
+	@mass -= 0.8
+	@mass *= 0.75
+	@mass += 0.8
+
+	@MODULE[ModuleEnginesFX]:HAS[#runningEffectName[gimbal_Running]]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@ratio = 0.1
+		}
+
+		// LH2 fuel is more efficient than LF.
+		@atmosphereCurve
+		{
+			// ASL
+			@key,1[1, ] += 40
+
+			// Vacuum
+			@key,2[1, ] += 50
+		}
+	}
+}

--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsTaurus.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsTaurus.cfg
@@ -38,11 +38,11 @@
 		// LH2 fuel is more efficient than LF.
 		@atmosphereCurve
 		{
+			// Vacuum
+			@key,0[1, ] += 50
+
 			// ASL
 			@key,1[1, ] += 40
-
-			// Vacuum
-			@key,2[1, ] += 50
 		}
 	}
 }


### PR DESCRIPTION
This is a pair of integration patches for some nuclear engines in the "SpaceTux Industries Recycled Parts" pack maintained by @linuxgurugamer:

* The first patch is for the LV-2N and LV-4N cluster engines, to keep their stats consistent with the stock LV-N after being patched for LH2.  I also added the LF/LH2 multi-mode switcher, again for consistency with the patched LV-N.
* The second patch is for the Taurus RS-2 engine, which is a little weird because it includes both a nuclear engine and a chemical engine, with separate nozzles that can run at the same time (i.e. not multi-mode alternatives).  The nuclear engine module already gets converted to LH2 by the `LH2NTRsDynamic` patch, but that leaves the chemical engine untouched, so it still burns LFO.  It's weird and inconvenient to have a part that needs both LF and LH2 fuel, so I've patched the chemical engine to use LH2+O instead.

@linuxgurugamer may want to weigh in on this before merging, particularly on the mass and Isp adjustments that I've made to the Taurus engine.

---

Some notes on the Isp balancing:

I built a test LFO rocket using the Taurus HCV command pod (also from SpaceTux), one Kerbodyne S3-14400 fuel tank, and the Taurus RS-2 engine.  Then I made an LH2+O version by replacing the Kerbodyne tank with four H375-144 cryo tanks (one of them only 80% full) and one H125-8 tank, which comes out to very nearly the same mass.

I temporarily disabled (deleted with MM) the nuclear engine module, leaving just the chemical one, so that Kerbal Engineer would report dV based on use of the chemical engine alone.  Then I compared the dV of the unpatched engine with the LFO rocket, and the patched engine with the LH2+O rocket, and made sure the latter was approximately the same but slightly better.

The chemical engine module of the RS-2 engine has a bug in the current SpaceTux release: its `atmosphereCurve` is the same as the nuclear one, which is much too efficient for a chemical engine.  That's expected to be fixed in the next release, but I don't know exactly what it'll be changed to, so for doing the above tests I changed it to that of the stock Twitch engine (which is what the RS-2's side nozzles appear to be based on).  But other Isp values should be OK as long as they're not drastically different.