### PR TITLE
Correctly handle multi-module (non-multi-mode) engines in generic NTR patch

### DIFF
--- a/GameData/KerbalAtomics/Patches/NTR/LH2NTRsDynamic.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/LH2NTRsDynamic.cfg
@@ -3,17 +3,18 @@
 
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer],!PROPELLANT[IntakeAir]],!MODULE[MultiModeEngine]]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
 {
-    @mass *= 0.75
-       @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = LqdHydrogen
-            @ratio = 1.0
-        }
-        @atmosphereCurve
-        {
-            @key,*[1, ] *= 1.1
-        }
+	@mass *= 0.75
+
+	@MODULE[ModuleEngines*]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.0
+		}
+		@atmosphereCurve
+		{
+			@key,*[1, ] *= 1.1
+		}
 	}
 }

--- a/GameData/KerbalAtomics/Patches/NTR/LH2NTRsDynamic.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/LH2NTRsDynamic.cfg
@@ -5,7 +5,7 @@
 {
 	@mass *= 0.75
 
-	@MODULE[ModuleEngines*]
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer],!PROPELLANT[IntakeAir]]
 	{
 		@PROPELLANT[LiquidFuel]
 		{

--- a/GameData/KerbalAtomics/Patches/NTR/LH2NTRsDynamic.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/LH2NTRsDynamic.cfg
@@ -1,26 +1,10 @@
 // MM Configs for changing various NTRs to use LqdHydrogen
 // Dynamic patch by TheToric
 
-@PART[*]:HAS[@MODULE[ModuleEnginesFX]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer],!PROPELLANT[IntakeAir]],!MODULE[MultiModeEngine]]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer],!PROPELLANT[IntakeAir]],!MODULE[MultiModeEngine]]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
 {
     @mass *= 0.75
-       @MODULE[ModuleEnginesFX]
-	{
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = LqdHydrogen
-            @ratio = 1.0
-        }
-        @atmosphereCurve
-        {
-            @key,*[1, ] *= 1.1
-        }
-	}
-}
-@PART[*]:HAS[@MODULE[ModuleEngines]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer],!PROPELLANT[IntakeAir]],!MODULE[MultiModeEngine]]:NEEDS[!NTRsUseLF]:FOR[zzLH2NTR]
-{
-    @mass *= 0.75
-       @MODULE[ModuleEngines]
+       @MODULE[ModuleEngines*]
     {
         @PROPELLANT[LiquidFuel]
         {


### PR DESCRIPTION
The generic NTR patch excludes multi-mode engines, but a part can also have multiple engine modules that operate independently (not as multi-mode alternatives).  Though unusual, it's possible to have both a nuclear and non-nuclear engine on the same part, or even two (independent) nuclear engines.

Previously, this patch would modify the part's first engine module, on the assumption that it's the only one (on a non-multi-mode part).  On a part with multiple independent engine modules, that could lead to accidentally patching the non-nuclear engine instead of the nuclear one, or patching just one of several nuclear engines.  By adding the nuclear `:HAS` criteria to the `@MODULE` block (not just the whole `@PART`), it'll correctly patch only the nuclear engine modules even if a non-nuclear one comes first, and *all* the nuclear engine modules if there's more than one.

I also merged the separate-but-identical patches for `ModuleEngines` and `ModuleEnginesFX` into a single patch for both.  That's needed to correctly handle the case where a part uses both (e.g. one of each on the same part).

---

The motivation for this change is the Taurus RS-2 engine in the "SpaceTux Industries Recycled Parts" pack, which I was recently experimenting with in connection with PR #48.  It's not a multi-mode engine, but it has two engine modules that work independently and can run at the same time.  One of them is nuclear, and the other is currently chemical, but it used to be nuclear (i.e. two nuclear engines on the same part) and @linuxgurugamer has said he might add an optional patch to change it back to nuclear.  Without this change to `LH2NTRsDynamic.cfg`, that second nuclear engine module won't get patched for LH2.