### PR TITLE
Draft: MissingHistory NTR and NTE configs

### DIFF
--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsMissingHistorycfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsMissingHistorycfg
@@ -1,0 +1,321 @@
+// Missing History CANDLE
+@PART[nuclearEngine_size0]:NEEDS[MissingHistory]:BEFORE[zzLH2NTR]
+{	
+	!MODULE[ModuleAlternator] {}
+	MODULE
+	{
+		name = ModuleRadioisotopeGenerator
+		BasePower = 0.25
+		HalfLife = 8.35
+		EasyMode = true
+	}
+	MODULE
+	{
+		name = ModuleCoreHeat
+		CoreTempGoal = 350
+		CoreToPartRatio = 0.1
+		CoreTempGoalAdjustment = 0
+		CoreEnergyMultiplier = 0.01
+		HeatRadiantMultiplier = 0.01
+		CoolingRadiantMultiplier = 0
+		HeatTransferMultiplier = 0
+		CoolantTransferMultiplier = 0
+		radiatorCoolingFactor = 0
+		radiatorHeatingFactor = 0
+		MaxCalculationWarp = 1000
+		CoreShutdownTemp = 10000
+		MaxCoolant = 0
+		PassiveEnergy
+		{
+			key = 0  25000
+			key = 200  10000
+			key = 250  50
+			key = 300 25
+			key = 350 0
+		}
+	}
+	
+	@EFFECTS
+	{
+		fx-sc-core
+		{
+			// Copy from the corresponding effect.
+			#../running_closed/AUDIO {}
+			#../running_closed/MODEL_MULTI_PARTICLE {}
+		}
+	}
+	
+	@mass = 0.135
+
+	!MODULE[ModuleEnginesFX] {}
+	MODULE
+	{
+		name = MultiModeEngine
+		primaryEngineID = LF
+		secondaryEngineID = LH2
+		primaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LF
+		secondaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LH2
+	}
+	
+	MODULE
+	{
+		name = ModuleEnginesFX
+		engineID = LF
+		runningEffectName = running_closed
+		thrustVectorTransformName = thrustTransform
+		exhaustDamage = True
+		ignitionThreshold = 0.1
+		EngineType = Nuclear
+		minThrust = 0
+		maxThrust = 3
+		heatProduction = 5
+		PROPELLANT
+		{
+			name = LiquidFuel
+			ratio = 0.9
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 625
+			key = 1 100
+			key = 2 0.001
+		}	
+	}
+	
+	MODULE
+	{
+		name = ModuleEnginesFX
+		engineID = LH2
+		runningEffectName = fx-sc-core
+		thrustVectorTransformName = thrustTransform
+		exhaustDamage = True
+		ignitionThreshold = 0.1
+		EngineType = Nuclear
+		minThrust = 0
+		maxThrust = 3
+		heatProduction = 5
+		PROPELLANT
+		{
+			name = LqdHydrogen
+			ratio = 1.0
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 700
+			key = 1 150
+			key = 2 0.001
+		}	
+	}
+}
+
+// Missing History BEACON
+@PART[nuclearEngine_1p5]:NEEDS[MissingHistory]:BEFORE[zzLH2NTR]
+{
+	@mass *= 0.75
+	
+	@EFFECTS
+	{
+		fx-sc-core
+		{
+			#../running_closed/AUDIO {}
+			#../running_closed/MODEL_MULTI_PARTICLE {}
+		}
+	}
+	
+	!MODULE[ModuleEnginesFX] {}
+	MODULE
+	{
+		name = MultiModeEngine
+		primaryEngineID = LF
+		secondaryEngineID = LH2
+		primaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LF
+		secondaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LH2
+	}
+	
+	MODULE
+	{
+		name = ModuleEnginesFX
+		engineID = LF
+		runningEffectName = running_closed
+		thrustVectorTransformName = thrustPoint
+		exhaustDamage = True
+		ignitionThreshold = 0.1
+		EngineType = Nuclear
+		minThrust = 0
+		maxThrust = 120
+		heatProduction = 7
+		exhaustDamageMaxRange = 8
+		exhaustDamageDistanceOffset = 0.1
+		PROPELLANT
+		{
+			name = LiquidFuel
+			ratio = 0.9
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 900
+			key = 1 140
+			key = 2 0.001
+		}	
+	}
+	
+	MODULE
+	{
+		name = ModuleEnginesFX
+		engineID = LH2
+		runningEffectName = fx-sc-core
+		thrustVectorTransformName = thrustPoint
+		exhaustDamage = True
+		ignitionThreshold = 0.1
+		EngineType = Nuclear
+		minThrust = 0
+		maxThrust = 120
+		heatProduction = 7
+		exhaustDamageMaxRange = 8
+		exhaustDamageDistanceOffset = 0.1
+		PROPELLANT
+		{
+			name = LqdHydrogen
+			ratio = 1.0
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 1600
+			key = 1 950
+			key = 2 500
+			key = 10 1
+		}	
+	}
+}
+
+@PART[nuclearEngine_1p5]:NEEDS[NearFutureElectrical&MissingHistory]:BEFORE[zzLH2NTR]
+{
+	@mass -= 1.1
+	// $865 per U
+	@cost += 86500
+	
+	!MODULE[ModuleAlternator] {}
+	MODULE
+	{
+		name = ModuleUpdateOverride
+	}
+	MODULE
+	{
+		name = FissionReactor
+		StartActionName = #LOC_NFElectrical_ModuleFissionReactor_Action_StartActionName
+		StopActionName = #LOC_NFElectrical_ModuleFissionReactor_Action_StopActionName
+		ToggleActionName = #LOC_NFElectrical_ModuleFissionReactor_Action_ToggleActionName
+
+		// Ramp up power based on throttle
+		FollowThrottle = true
+
+		// Heat animation, plays when above nominal temp
+		// OverheatAnimation = Reactor_1MW_Heat
+
+		// Heat to generate (kW *50)
+		HeatGeneration = 55000
+
+		// Above this temp more power output but risky
+		NominalTemperature = 3000
+		// Above this temp, reactor takes damage
+		CriticalTemperature = 3400
+
+		MaximumTemperature = 3800
+
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.01
+
+		// Base lifetime calculations off this resource
+		FuelName = EnrichedUranium
+
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.00027
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.00027
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+		// Disables stock converter functions DO NOT CHANGE
+		UseSpecializationBonus = false
+		AutoShutdown = false
+		DefaultShutoffTemp = 0.90
+		GeneratesHeat = false
+		TemperatureModifier
+		{
+			key = 0 0
+		}
+	}
+	MODULE
+	{
+		name = ModuleCoreHeatNoCatchup
+		CoreTempGoal = 3000					//Internal temp goal - we don't transfer till we hit this point
+		CoreToPartRatio = 0.1				//Scale back cooling if the part is this % of core temp
+		CoreTempGoalAdjustment = 0			//Dynamic goal adjustment
+		CoreEnergyMultiplier = 0.001		//What percentage of our core energy do we transfer to the part
+		HeatRadiantMultiplier = 0.05		//If the core is hotter, how much heat radiates?
+		CoolingRadiantMultiplier = 0		//If the core is colder, how much radiates?
+		HeatTransferMultiplier = 0			//If the part is hotter, how much heat transfers in?
+		CoolantTransferMultiplier = 0.01	//If the part is colder, how much of our energy can we transfer?
+		radiatorCoolingFactor = 1			//How much energy we pull from core with an active radiator?  >= 1
+		radiatorHeatingFactor = 0.01		//How much energy we push to the active radiator
+		MaxCalculationWarp = 1000			//Based on how dramatic the changes are, this is the max rate of change
+		CoreShutdownTemp = 3800				//At what core temperature do we shut down all generators on this part?
+		MaxCoolant = 1100					//Maximum amount of radiator capacity we can consume - 50 = 1 small
+	}
+	MODULE
+	{
+		name = FissionFlowRadiator
+		exhaustCooling = 1100
+		maxEnergyTransfer = 55000
+		CoolingDecayRate = 100
+	}
+	RESOURCE
+	{
+		name = EnrichedUranium
+		amount = 100
+		maxAmount = 100
+	}
+	RESOURCE
+	{
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 100
+	}
+	MODULE
+	{
+		name = FissionEngine
+		HeatUsed = 1100
+		TempIspScale
+		{
+			key = 300 0
+			key = 1000 0.2
+			key = 3000 1.0
+			key = 4000 1.3
+		}
+	}
+	MODULE
+	{
+		name = RadioactiveStorageContainer
+		DangerousFuel = DepletedFuel
+		SafeFuel = EnrichedUranium
+		// What enginer level is needed to transfer the safe fuel
+		EngineerLevelForSafe = 1
+		// What enginer level is needed to transfer the dangerous fuel
+		EngineerLevelForDangerous = 3
+		// Max temp for transferring fuel into or out of the part
+		MaxTempForTransfer = 400
+		// kW of heat per unit of waste
+		HeatFluxPerWasteUnit = 5
+	}
+}


### PR DESCRIPTION
- gives the Missing History versions of the Atomic Age Engines customized configs instead of relying on zzLH2NTR, stats based on existing Atomic Age configs
- NTE config for Beacon can be moved to a separate file if needed