### PR TITLE
Stopgap Compatibility with ReStock

### DIFF
--- a/Extras/NearFutureElectricaNTRs/Squad/nuclearEngine.cfg
+++ b/Extras/NearFutureElectricaNTRs/Squad/nuclearEngine.cfg
@@ -1,24 +1,19 @@
 // MM Config to set fancy nuclear engines if NFE is around
-@PART[nuclearEngine]:NEEDS[NearFutureElectrical]:AFTER[KerbalAtomics]
-{
+@PART[nuclearEngine]:NEEDS[NearFutureElectrical]:AFTER[KerbalAtomics] {
 	// 0.01097 mass per unit of U
 	@mass -= 0.5485
-	// $865 per U, but CRP U already costs this amount
-	// @cost += 43250
 	!MODULE[ModuleAlternator] {}
-	MODULE
-	{
+	MODULE {
 		name = ModuleUpdateOverride
 	}
-	MODULE
-	{
+	MODULE {
 		name = FissionReactor
 		StartActionName = #LOC_NFElectrical_ModuleFissionReactor_Action_StartActionName
 		StopActionName = #LOC_NFElectrical_ModuleFissionReactor_Action_StopActionName
 		ToggleActionName = #LOC_NFElectrical_ModuleFissionReactor_Action_ToggleActionName
 
-    // Ramp up power based on throttle
-    FollowThrottle = true
+		// Ramp up power based on throttle
+		FollowThrottle = true
 
 		// Heat animation, plays when above nominal temp
 		// OverheatAnimation = Reactor_1MW_Heat
@@ -40,14 +35,12 @@
 		// Base lifetime calculations off this resource
 		FuelName = EnrichedUranium
 
-		INPUT_RESOURCE
-		{
+		INPUT_RESOURCE {
 			ResourceName = EnrichedUranium
 			Ratio = 0.00027
 			FlowMode = NO_FLOW
 		}
-		OUTPUT_RESOURCE
-		{
+		OUTPUT_RESOURCE {
 			ResourceName = DepletedFuel
 			Ratio = 0.00027
 			DumpExcess = false
@@ -58,61 +51,53 @@
 		AutoShutdown = false
 		DefaultShutoffTemp = 0.90
 		GeneratesHeat = false
-		TemperatureModifier
-		{
+		TemperatureModifier {
 			key = 0 0
 		}
 	}
-	MODULE
-	{
+	MODULE {
 		name = ModuleCoreHeatNoCatchup
-		CoreTempGoal = 3000					//Internal temp goal - we don't transfer till we hit this point
-		CoreToPartRatio = 0.1				//Scale back cooling if the part is this % of core temp
-		CoreTempGoalAdjustment = 0			//Dynamic goal adjustment
-		CoreEnergyMultiplier = 0.001			//What percentage of our core energy do we transfer to the part
-		HeatRadiantMultiplier = 0.05		//If the core is hotter, how much heat radiates?
-		CoolingRadiantMultiplier = 0		//If the core is colder, how much radiates?
-		HeatTransferMultiplier = 0			//If the part is hotter, how much heat transfers in?
-		CoolantTransferMultiplier = 0.01	//If the part is colder, how much of our energy can we transfer?
-		radiatorCoolingFactor = 1			//How much energy we pull from core with an active radiator?  >= 1
-		radiatorHeatingFactor = 0.01		//How much energy we push to the active radiator
-		MaxCalculationWarp = 1000			//Based on how dramatic the changes are, this is the max rate of change
-		CoreShutdownTemp = 3800				//At what core temperature do we shut down all generators on this part?
-		MaxCoolant = 1100					//Maximum amount of radiator capacity we can consume - 50 = 1 small
+		CoreTempGoal = 3000 //Internal temp goal - we don't transfer till we hit this point
+		CoreToPartRatio = 0.1 //Scale back cooling if the part is this % of core temp
+		CoreTempGoalAdjustment = 0 //Dynamic goal adjustment
+		CoreEnergyMultiplier = 0.001 //What percentage of our core energy do we transfer to the part
+		HeatRadiantMultiplier = 0.05 //If the core is hotter, how much heat radiates?
+		CoolingRadiantMultiplier = 0 //If the core is colder, how much radiates?
+		HeatTransferMultiplier = 0 //If the part is hotter, how much heat transfers in?
+		CoolantTransferMultiplier = 0.01 //If the part is colder, how much of our energy can we transfer?
+		radiatorCoolingFactor = 1 //How much energy we pull from core with an active radiator?  >= 1
+		radiatorHeatingFactor = 0.01 //How much energy we push to the active radiator
+		MaxCalculationWarp = 1000 //Based on how dramatic the changes are, this is the max rate of change
+		CoreShutdownTemp = 3800 //At what core temperature do we shut down all generators on this part?
+		MaxCoolant = 1100 //Maximum amount of radiator capacity we can consume - 50 = 1 small
 	}
-	MODULE
-	{
+	MODULE {
 		name = FissionFlowRadiator
 		exhaustCooling = 1100
 		maxEnergyTransfer = 55000
 		CoolingDecayRate = 100
 	}
-	RESOURCE
-	{
+	RESOURCE {
 		name = EnrichedUranium
 		amount = 50
 		maxAmount = 50
 	}
-	RESOURCE
-	{
+	RESOURCE {
 		name = DepletedFuel
 		amount = 0
 		maxAmount = 50
 	}
-	MODULE
-	{
+	MODULE {
 		name = FissionEngine
 		HeatUsed = 1100
-		TempIspScale
-		{
+		TempIspScale {
 			key = 300 0
 			key = 1000 0.2
 			key = 3000 1.0
 			key = 4000 1.3
 		}
 	}
-	MODULE
-	{
+	MODULE {
 		name = RadioactiveStorageContainer
 		DangerousFuel = DepletedFuel
 		SafeFuel = EnrichedUranium
@@ -125,7 +110,7 @@
 		// kW of heat per unit of waste
 		HeatFluxPerWasteUnit = 5
 	}
-	@MODULE[ModuleEnginesFX] {
-		@heatProduction *= 0.01
+	@MODULE[ModuleEnginesFX],* {
+		%heatProduction *= 0.01
 	}
 }

--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
@@ -63,6 +63,15 @@
 			}
 		}
 		fx-sc-lf-core {
+			AUDIO {
+				channel = Ship
+				clip = sound_rocket_hard
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
 			MODEL_MULTI_PARTICLE {
 				modelName = KerbalAtomics/FX/fx-sc-lh2-125-core
 				transformName = thrustTransform
@@ -293,8 +302,8 @@
 		!powerEffectName
 
 		@PROPELLANT[LiquidFuel] {
-				@name = LqdHydrogen
-				@ratio = 1.0
+			@name = LqdHydrogen
+			@ratio = 1.0
 		}
 
 		!atmosphereCurve {}

--- a/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
+++ b/GameData/KerbalAtomics/Patches/NTR/hydrogenNTRsSQUAD.cfg
@@ -1,54 +1,45 @@
 // MM Configs for changing various NTRs to use LqdHydrogen
 
 // LV-N (stock)
-@PART[nuclearEngine]:NEEDS[!NTRsUseLF]
-{
+@PART[nuclearEngine]:NEEDS[!NTRsUseLF,!ReStock] {
 	@mass = 2.25
 
-	EFFECTS
-	{
-		engage
-	  {
-		AUDIO
-		{
-		  channel = Ship
-		  clip = sound_vent_medium
-		  volume = 1.0
-		  pitch = 2.0
-		  loop = false
+	!EFFECTS,* {}
+	EFFECTS {
+		engage {
+			AUDIO {
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
 		}
-	  }
-		flameout
-		{
-			PREFAB_PARTICLE
-			{
+		flameout {
+			PREFAB_PARTICLE {
 				prefabName = fx_exhaustSparks_flameout_2
 				transformName = thrustTransform
 				oneShot = true
 			}
-			AUDIO
-		{
-		  channel = Ship
-		  clip = sound_explosion_low
-		  volume = 1.0
-		  pitch = 2.0
-		  loop = false
-		}
-		}
-		fx-sc-lh2-core
-		{
-			AUDIO
-			{
-				  channel = Ship
-				  clip = sound_rocket_hard
-				  volume = 0.0 0.0
-				  volume = 1.0 1.0
-				  pitch = 0.0 0.2
-				  pitch = 1.0 1.0
-				  loop = true
+			AUDIO {
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
 			}
-			MODEL_MULTI_PARTICLE
-			{
+		}
+		fx-sc-lh2-core {
+			AUDIO {
+				channel = Ship
+				clip = sound_rocket_hard
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+			MODEL_MULTI_PARTICLE {
 				modelName = KerbalAtomics/FX/fx-sc-lh2-125-core
 				transformName = thrustTransform
 				emission = 0.0 0.0
@@ -59,11 +50,9 @@
 				speed = 1.0 1.0
 			}
 		}
-		fx-sc-lh2-plume
-		{
-			MODEL_MULTI_PARTICLE
-			{
-				modelName =KerbalAtomics/FX/fx-sc-lh2-125-plume
+		fx-sc-lh2-plume {
+			MODEL_MULTI_PARTICLE {
+				modelName = KerbalAtomics/FX/fx-sc-lh2-125-plume
 				transformName = thrustTransform
 				emission = 0.0 0.0
 				emission = 0.01 0.1
@@ -73,20 +62,33 @@
 				speed = 1.0 1.0
 			}
 		}
-		fx-sc-lf-core
-		{
-			// Copy from the corresponding LH2 effect.
-			#../fx-sc-lh2-core/AUDIO {}
-			#../fx-sc-lh2-core/MODEL_MULTI_PARTICLE {}
+		fx-sc-lf-core {
+			MODEL_MULTI_PARTICLE {
+				modelName = KerbalAtomics/FX/fx-sc-lh2-125-core
+				transformName = thrustTransform
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
 		}
-		fx-sc-lf-plume
-		{
-			// Copy from the corresponding LH2 effect.
-			#../fx-sc-lh2-plume/MODEL_MULTI_PARTICLE {}
+		fx-sc-lf-plume {
+			MODEL_MULTI_PARTICLE {
+				modelName = KerbalAtomics/FX/fx-sc-lh2-125-plume
+				transformName = thrustTransform
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
 		}
 	}
-	MODULE
-	{
+
+	MODULE {
 		name = MultiModeEngine
 		primaryEngineID = LF
 		secondaryEngineID = LH2
@@ -94,33 +96,24 @@
 		secondaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LH2
 	}
 
-	@MODULE[ModuleAlternator]
-	{
+	@MODULE[ModuleAlternator] {
 		preferMultiMode = true
 	}
 
-	// The LH2NTRsDynamic patch should have changed this engine to burn LH2
-	// already, but apply some part-specific tweaks.
-	@MODULE[ModuleEngines]   {
+	@MODULE[ModuleEngines] {
 		@name = ModuleEnginesFX
 		engineID = LH2
 		runningEffectName = fx-sc-lh2-core
 		powerEffectName = fx-sc-lh2-plume
 		@fxOffset = 0, 0, 1.5
 
-		// Redundant since LH2NTRsDynamic does this already, but do it
-		// again as a fail-safe in case that patch is removed.
-		@PROPELLANT[LiquidFuel]
-		{
+		@PROPELLANT[LiquidFuel] {
 			@name = LqdHydrogen
 			@ratio = 1.0
 		}
 
-		// Part-specific Isp values, overriding the generic adjustment
-		// done by LH2NTRsDynamic.
 		!atmosphereCurve {}
-		atmosphereCurve
-		{
+		atmosphereCurve {
 			key = 0 900
 			key = 1 400
 			key = 2 50
@@ -128,9 +121,7 @@
 		}
 	}
 
-	// Copy the LH2 engine module to make an LF-burning alternative mode.
-	$MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]
-	{
+	+MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]] {
 		@engineID = LF
 		@runningEffectName = fx-sc-lf-core
 		@powerEffectName = fx-sc-lf-plume
@@ -147,5 +138,193 @@
 			key = 1 185
 			key = 2 0.001
 		}
+	}
+}
+
+// LV-N (ReStock)
+@PART[nuclearEngine]:NEEDS[!NTRsUseLF]:AFTER[ReStock] {
+	@mass = 2.25
+
+	!EFFECTS,* {}
+	EFFECTS {
+		engage {
+			AUDIO {
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout {
+			AUDIO {
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		fx-sc-lh2 {
+      		AUDIO {
+				channel = Ship
+				clip = sound_rocket_hard
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+      		}
+			MODEL_MULTI_PARTICLE {
+				name = core
+				modelName = ReStock/FX/restock-fx-nerv-core-1
+				transformName = fxTransformCore
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
+			MODEL_MULTI_PARTICLE {
+				name = turbo
+				modelName = ReStock/FX/restock-fx-nerv-turbo-1
+				transformName = fxTransformTurbo
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
+			MODEL_MULTI_PARTICLE {
+				name = plume
+				modelName = ReStock/FX/restock-fx-nerv-plume-1
+				transformName = fxTransformPlume
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
+			PREFAB_PARTICLE {
+				prefabName = fx_smokeTrail_light
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.05 0.0
+				emission = 0.075 0.25
+				emission = 1.0 1.25
+				speed = 0.0 0.25
+				speed = 1.0 1.0
+			}
+		}
+		fx-sc-lf {
+      		AUDIO {
+				channel = Ship
+				clip = sound_rocket_hard
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+      		}
+			MODEL_MULTI_PARTICLE {
+				name = core
+				modelName = ReStock/FX/restock-fx-nerv-core-1
+				transformName = fxTransformCore
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
+			MODEL_MULTI_PARTICLE {
+				name = turbo
+				modelName = ReStock/FX/restock-fx-nerv-turbo-1
+				transformName = fxTransformTurbo
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
+			MODEL_MULTI_PARTICLE {
+				name = plume
+				modelName = ReStock/FX/restock-fx-nerv-plume-1
+				transformName = fxTransformPlume
+				emission = 0.0 0.0
+				emission = 0.01 0.1
+				emission = 0.075 0.25
+				emission = 1.0 1.0
+				speed = 0.0 0.35
+				speed = 1.0 1.0
+			}
+			PREFAB_PARTICLE {
+				prefabName = fx_smokeTrail_light
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.05 0.0
+				emission = 0.075 0.25
+				emission = 1.0 1.25
+				speed = 0.0 0.25
+				speed = 1.0 1.0
+			}
+		}
+	}
+
+	MODULE {
+		name = MultiModeEngine
+		primaryEngineID = LF
+		secondaryEngineID = LH2
+		primaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LF
+		secondaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LH2
+	}
+
+	@MODULE[ModuleAlternator] {
+		%preferMultiMode = true
+	}
+
+	@MODULE[ModuleEnginesFX] {
+		%engineID = LH2
+		%runningEffectName = fx-sc-lh2
+		!powerEffectName
+
+		@PROPELLANT[LiquidFuel] {
+				@name = LqdHydrogen
+				@ratio = 1.0
+		}
+
+		!atmosphereCurve {}
+		atmosphereCurve {
+			key = 0 900
+			key = 1 400
+			key = 2 50
+			key = 10 1
+		}
+	}
+
+	+MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]] {
+		@engineID = LF
+		@runningEffectName = fx-sc-lf
+		@PROPELLANT[LqdHydrogen]
+		{
+			@name = LiquidFuel
+			@ratio = 0.9
+		}
+
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 600
+			key = 1 185
+			key = 2 0.001
+		}
+	}
+
+	@MODULE[FXModuleThrottleEffects],* {
+		preferMultiMode = true
 	}
 }


### PR DESCRIPTION
Good day. Below is a draft of a placeholder compatibility patch for ReStock's LV-N.

I haven't tested it with the new RealPlume configs, though I suspect the changes I made here won't be enough. I also deferred using copy operations for the EFFECTS {} in the working files, until decisions for what plumes to use are made (i.e. use KerbalAomics plumes for LH or use ReStock for both LH & LF).

Please change the files as you see fit. Please also let me know if there certain things you wish to have changed.

(sorry for the unnecessary whitespace changes - I am not comfortable with the GitHub text editor, and the text editor I used doesn't work well with GitHub's whitespace)