### PR TITLE
Dev

### DIFF
--- a/GameData/KerbalAtomics/Patches/KerbalAtomicsEngineLightRelit.cfg
+++ b/GameData/KerbalAtomics/Patches/KerbalAtomicsEngineLightRelit.cfg
@@ -1,9 +1,7 @@
-// Tweaks the colour of the EngineLight lights
-//For Kerbal Atomics v. 1.0.0 and
-//EngineLight by LinuxGuruGamer for KSP 1.7 (Continuation of EngineLighting by tajampi)
+//Tweaks the color of the EngineLight by tajampi & continued by LinuxGuruGamer https://github.com/linuxgurugamer/EngineLightRelit/releases
+//Created with Kerbal Atomics v. 1.0.2 & KSP 1.7.0 by KSP forum user Nightside 2019.06.02
 
-
-
+//Patch Engine Light Colors to a rosy lavender-pink glow
 //Patch Engine Light Colors
 //0.625 - NV-10 'Eel' Atomic Rocket Motor
 @PART[ntr-sc-0625-1]:AFTER[EngineLight]:NEEDS[EngineLight]

--- a/GameData/KerbalAtomics/Patches/KerbalAtomicsEngineLightRelit.cfg
+++ b/GameData/KerbalAtomics/Patches/KerbalAtomicsEngineLightRelit.cfg
@@ -1,0 +1,241 @@
+// Tweaks the colour of the EngineLight lights
+//For Kerbal Atomics v. 1.0.0 and
+//EngineLight by LinuxGuruGamer for KSP 1.7 (Continuation of EngineLighting by tajampi)
+
+
+
+//Patch Engine Light Colors
+//0.625 - NV-10 'Eel' Atomic Rocket Motor
+@PART[ntr-sc-0625-1]:AFTER[EngineLight]:NEEDS[EngineLight]
+{
+    @MODULE[EngineLightEffect]
+    {
+        //name = EngineLightEffect
+        %enableEmissiveLight = true // engines with no emissive will shut this off automatically
+        %engineEmissiveMultiplier = 2 // 1.33 //scale emissive brightness
+        %jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+        %lightFadeCoefficient = 0.7
+        %lightPower = .25 
+        %lightRange = 3 // 9.0 small engine
+
+        %multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+        // main engine light colour
+        %exhaustRed = 1
+        %exhaustGreen = 0.55 // 0.88
+        %exhaustBlue = 0.78 //0.68
+
+        %emissiveOffsetZ = #$../node_stack_bottom[1]$
+        @emissiveOffsetZ *=-0.67
+        %exhaustOffsetZ = #$../node_stack_bottom[1]$
+       @exhaustOffsetZ *= -1.1
+    }    
+}
+
+//1.25
+// Trimodal Solid Core - 1.25m - Neptune
+@PART[ntr-sc-125-1]:AFTER[EngineLight]:NEEDS[EngineLight]
+{
+    @MODULE[EngineLightEffect]
+    {
+        //name = EngineLightEffect
+        %enableEmissiveLight = true // engines with no emissive will shut this off automatically
+        %engineEmissiveMultiplier = 3 // 1.33 //scale emissive brightness
+        %jitterMultiplier = 0.3 //0.1 // controls main engine light flicker intensity
+        %lightFadeCoefficient = 0.8
+        %lightPower = 1 
+        %lightRange = 12 // 9.0 small engine
+
+        %multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+        // main engine light colour
+        %exhaustRed = 1
+        %exhaustGreen = 0.55 // 0.88
+        %exhaustBlue = 0.78 //0.68
+
+        %emissiveOffsetZ = #$../node_stack_bottom[1]$
+        @emissiveOffsetZ *=-0.67
+        %exhaustOffsetZ = #$../node_stack_bottom[1]$
+       @exhaustOffsetZ *= -1.1
+    }    
+}
+
+// Pebble Bed Solid Core - 1.25m - Stubber
+@PART[ntr-sc-125-2]:AFTER[EngineLight]:NEEDS[EngineLight]
+{
+    @MODULE[EngineLightEffect]
+    {
+        //name = EngineLightEffect
+        %enableEmissiveLight = true // engines with no emissive will shut this off automatically
+        %engineEmissiveMultiplier = 2.5 // 1.33 //scale emissive brightness
+        %jitterMultiplier = 0.3 //0.1 // controls main engine light flicker intensity
+        %lightFadeCoefficient = 0.8
+        %lightPower = 1 
+        %lightRange = 7 // 9.0 small engine
+
+        %multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+                // main engine light colour
+        %exhaustRed = 1
+        %exhaustGreen = 0.55 // 0.88
+        %exhaustBlue = 0.78 //0.68
+
+        %emissiveOffsetZ = #$../node_stack_bottom[1]$
+        @emissiveOffsetZ *=-0.67
+        %exhaustOffsetZ = #$../node_stack_bottom[1]$
+       @exhaustOffsetZ *= -1.1
+    }    
+}
+
+// 1.25 LV-N Nerva
+@PART[nuclearEngine]:AFTER[EngineLight]:NEEDS[EngineLight]
+{
+    @MODULE[EngineLightEffect]
+    {
+        //name = EngineLightEffect
+        %enableEmissiveLight = true // engines with no emissive will shut this off automatically
+        %engineEmissiveMultiplier = 3 // 1.33 //scale emissive brightness
+        %jitterMultiplier = 0.3 //0.1 // controls main engine light flicker intensity
+        %lightFadeCoefficient = 0.8
+        %lightPower = 1 
+        %lightRange = 10 // 9.0 small engine
+
+        %multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+        // main engine light colour
+        %exhaustRed = 1
+        %exhaustGreen = 0.55 // 0.88
+        %exhaustBlue = 0.78 //0.68
+
+        %emissiveOffsetZ = #$../node_stack_bottom[1]$
+        @emissiveOffsetZ *=-0.67
+        %exhaustOffsetZ = #$../node_stack_bottom[1]$
+       @exhaustOffsetZ *= -1.1
+    }    
+}
+
+@PART[ntr-sc-25-1]:AFTER[EngineLight]:NEEDS[EngineLight]
+{
+    @MODULE[EngineLightEffect]
+    {
+        //name = EngineLightEffect
+        %enableEmissiveLight = true // engines with no emissive will shut this off automatically
+        %engineEmissiveMultiplier = 3 // 1.33 //scale emissive brightness
+        %jitterMultiplier = 0.3 //0.1 // controls main engine light flicker intensity
+        %lightFadeCoefficient = 0.8
+        %lightPower = 1 
+        %lightRange = 10 // 9.0 small engine
+
+        %multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+       
+        // main engine light colour
+        %exhaustRed = 1
+        %exhaustGreen = 0.55 // 0.88
+        %exhaustBlue = 0.78 //0.68
+
+        %emissiveOffsetZ = #$../node_stack_bottom[1]$
+        @emissiveOffsetZ *=-0.67
+        %exhaustOffsetZ = #$../node_stack_bottom[1]$
+       @exhaustOffsetZ *= -1.1
+    }    
+}
+@PART[ntr-gc-25-1]:AFTER[EngineLight]:NEEDS[EngineLight]
+{
+    @MODULE[EngineLightEffect]
+    {
+        //name = EngineLightEffect
+        %enableEmissiveLight = true // engines with no emissive will shut this off automatically
+        %engineEmissiveMultiplier = 3 // 1.33 //scale emissive brightness
+        %jitterMultiplier = 0.3 //0.1 // controls main engine light flicker intensity
+        %lightFadeCoefficient = 0.8
+        %lightPower = 1 
+        %lightRange = 12 // 9.0 small engine
+
+        %multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+        // main engine light colour
+        %exhaustRed = 1
+        %exhaustGreen = 0.55 // 0.88
+        %exhaustBlue = 0.78 //0.68
+
+        %emissiveOffsetZ = #$../node_stack_bottom[1]$
+        @emissiveOffsetZ *=-0.67
+        %exhaustOffsetZ = #$../node_stack_bottom[1]$
+       @exhaustOffsetZ *= -1.1
+    }    
+}
+@PART[ntr-gc-25-2]:AFTER[EngineLight]:NEEDS[EngineLight]
+{
+    @MODULE[EngineLightEffect]
+    {
+        //name = EngineLightEffect
+        %enableEmissiveLight = true // engines with no emissive will shut this off automatically
+        %engineEmissiveMultiplier = 4 // 1.33 //scale emissive brightness
+        %jitterMultiplier = 0.3 //0.1 // controls main engine light flicker intensity
+        %lightFadeCoefficient = 0.8
+        %lightPower = 1 
+        %lightRange = 14 // 9.0 small engine
+
+        %multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+        // main engine light colour
+        %exhaustRed = 1
+        %exhaustGreen = 0.55 // 0.88
+        %exhaustBlue = 0.78 //0.68
+
+        %emissiveOffsetZ = #$../node_stack_bottom[1]$
+        @emissiveOffsetZ *=-0.67
+        %exhaustOffsetZ = #$../node_stack_bottom[1]$
+       @exhaustOffsetZ *= -1.1
+    }    
+}
+@PART[ntr-gc-25-3]:AFTER[EngineLight]:NEEDS[EngineLight]
+{
+    @MODULE[EngineLightEffect]
+    {
+        //name = EngineLightEffect
+        %enableEmissiveLight = true // engines with no emissive will shut this off automatically
+        %engineEmissiveMultiplier = 4 // 1.33 //scale emissive brightness
+        %jitterMultiplier = 0.3 //0.1 // controls main engine light flicker intensity
+        %lightFadeCoefficient = 0.8
+        %lightPower = 1 
+        %lightRange = 18 // 9.0 small engine
+
+        %multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+        // main engine light colour
+        %exhaustRed = 1
+        %exhaustGreen = 0.55 // 0.88
+        %exhaustBlue = 0.78 //0.68
+
+        %emissiveOffsetZ = #$../node_stack_bottom[1]$
+        @emissiveOffsetZ *=-0.67
+        %exhaustOffsetZ = #$../node_stack_bottom[1]$
+       @exhaustOffsetZ *= -1.1
+    }    
+}
+@PART[ntr-sc-375-1]:AFTER[EngineLight]:NEEDS[EngineLight]
+{
+    @MODULE[EngineLightEffect]
+    {
+        //name = EngineLightEffect
+        %enableEmissiveLight = true // engines with no emissive will shut this off automatically
+        %engineEmissiveMultiplier = 2 // 1.33 //scale emissive brightness
+        %jitterMultiplier = 0.3 //0.1 // controls main engine light flicker intensity
+        %lightFadeCoefficient = 0.8
+        %lightPower = 1 
+        %lightRange = 20 // 9.0 small engine
+
+        %multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+        // main engine light colour
+        %exhaustRed = 1
+        %exhaustGreen = 0.55 // 0.88
+        %exhaustBlue = 0.78 //0.68
+
+        %emissiveOffsetZ = #$../node_stack_bottom[1]$
+        @emissiveOffsetZ *=-0.67
+        %exhaustOffsetZ = #$../node_stack_bottom[1]$
+       @exhaustOffsetZ *= -1.1
+    }    
+}


### PR DESCRIPTION
This patches the generic EngineLight module for the engines contained in this mod to give the plumes a rosy pink-blue light instead of the default bright yellow-white light.
![screenshot16](https://user-images.githubusercontent.com/20480557/58777962-8630cb00-8585-11e9-8192-2a70d09d5461.png)
