### PR TITLE
Fix LH2NTR MissingHistory patch interaction with RealPlume

### DIFF
--- a/Extras/KerbalAtomicsLH2NTRModSupport/hydrogenNTRsMissingHistory.cfg
+++ b/Extras/KerbalAtomicsLH2NTRModSupport/hydrogenNTRsMissingHistory.cfg
@@ -37,11 +37,27 @@
 	
 	@EFFECTS
 	{
-		fx-sc-core
+		fx-sc-core:NEEDS[!RealPlume-Stock]
 		{
 			// Copy from the corresponding effect.
 			#../running_closed/AUDIO {}
 			#../running_closed/MODEL_MULTI_PARTICLE {}
+		}
+
+		// If RealPlume is installed, it deletes the "running_closed" effect at an
+		// earlier stage in the MM patching process, replacing it with a different
+		// effect and changing the engine module accordingly.  Since this patch
+		// deletes the engine module below and replaces it with two that expect the
+		// original effect names, copy RealPlume's effect back to the original names.
+		running_closed:NEEDS[RealPlume-Stock]
+		{
+			#../Hydrogen-NTR-HighTemp/AUDIO {}
+			#../Hydrogen-NTR-HighTemp/MODEL_MULTI_SHURIKEN_PERSIST {}
+		}
+		fx-sc-core:NEEDS[RealPlume-Stock]
+		{
+			#../Hydrogen-NTR-HighTemp/AUDIO {}
+			#../Hydrogen-NTR-HighTemp/MODEL_MULTI_SHURIKEN_PERSIST {}
 		}
 	}
 	
@@ -117,10 +133,27 @@
 	
 	@EFFECTS
 	{
-		fx-sc-core
+		fx-sc-core:NEEDS[!RealPlume-Stock]
 		{
+			// Copy from the corresponding effect.
 			#../running_closed/AUDIO {}
 			#../running_closed/MODEL_MULTI_PARTICLE {}
+		}
+
+		// If RealPlume is installed, it deletes the "running_closed" effect at an
+		// earlier stage in the MM patching process, replacing it with a different
+		// effect and changing the engine module accordingly.  Since this patch
+		// deletes the engine module below and replaces it with two that expect the
+		// original effect names, copy RealPlume's effect back to the original names.
+		running_closed:NEEDS[RealPlume-Stock]
+		{
+			#../Hydrogen-NTR/AUDIO {}
+			#../Hydrogen-NTR/MODEL_MULTI_SHURIKEN_PERSIST {}
+		}
+		fx-sc-core:NEEDS[RealPlume-Stock]
+		{
+			#../Hydrogen-NTR/AUDIO {}
+			#../Hydrogen-NTR/MODEL_MULTI_SHURIKEN_PERSIST {}
 		}
 	}
 	


### PR DESCRIPTION
The LH2NTR "extra" patch for two MissingHistory engines works by deleting the single-mode LF engine module and replacing it with a multi-mode LF/LH2 configuration.  As part of that, it needs to clone the engine's single effect definition to make two identical effects, since KSP doesn't correctly handle two engine modules sharing the same effect. 

When RealPlume is installed, it runs beforehand and deletes the "running_closed" effect, which breaks the LH2NTR patch that expects to copy from that effect.  To get the right result, the LH2NTR patch has to be aware of RealPlume's changes and copy from its replacement effect instead.

Other LH2NTR patches (besides the MissingHistory one) don't need this treatment.  The only other one that clones effects is the one for the LV-2N and LV-4N cluster engines, and it locally defines the same effects that it later clones, so they always exist.

Fixes: #74 