### PR TITLE
Update LH2NTR MissingHistory patch for RealPlume-Stock v1.5

### DIFF
--- a/Extras/KerbalAtomicsLH2NTRModSupport/hydrogenNTRsMissingHistory.cfg
+++ b/Extras/KerbalAtomicsLH2NTRModSupport/hydrogenNTRsMissingHistory.cfg
@@ -51,13 +51,15 @@
 		// original effect names, copy RealPlume's effect back to the original names.
 		running_closed:NEEDS[RealPlume-Stock]
 		{
-			#../Hydrogen-NTR-HighTemp/AUDIO {}
-			#../Hydrogen-NTR-HighTemp/MODEL_MULTI_SHURIKEN_PERSIST {}
+			#../Nuclear_SolidCore_LH2/AUDIO {}
+			#../Nuclear_SolidCore_LH2/MODEL_MULTI_SHURIKEN_PERSIST,0 {}
+			#../Nuclear_SolidCore_LH2/MODEL_MULTI_SHURIKEN_PERSIST,1 {}
 		}
 		fx-sc-core:NEEDS[RealPlume-Stock]
 		{
-			#../Hydrogen-NTR-HighTemp/AUDIO {}
-			#../Hydrogen-NTR-HighTemp/MODEL_MULTI_SHURIKEN_PERSIST {}
+			#../Nuclear_SolidCore_LH2/AUDIO {}
+			#../Nuclear_SolidCore_LH2/MODEL_MULTI_SHURIKEN_PERSIST,0 {}
+			#../Nuclear_SolidCore_LH2/MODEL_MULTI_SHURIKEN_PERSIST,1 {}
 		}
 	}
 	
@@ -147,13 +149,15 @@
 		// original effect names, copy RealPlume's effect back to the original names.
 		running_closed:NEEDS[RealPlume-Stock]
 		{
-			#../Hydrogen-NTR/AUDIO {}
-			#../Hydrogen-NTR/MODEL_MULTI_SHURIKEN_PERSIST {}
+			#../Nuclear_GasCore_LH2/AUDIO {}
+			#../Nuclear_GasCore_LH2/MODEL_MULTI_SHURIKEN_PERSIST,0 {}
+			#../Nuclear_GasCore_LH2/MODEL_MULTI_SHURIKEN_PERSIST,1 {}
 		}
 		fx-sc-core:NEEDS[RealPlume-Stock]
 		{
-			#../Hydrogen-NTR/AUDIO {}
-			#../Hydrogen-NTR/MODEL_MULTI_SHURIKEN_PERSIST {}
+			#../Nuclear_GasCore_LH2/AUDIO {}
+			#../Nuclear_GasCore_LH2/MODEL_MULTI_SHURIKEN_PERSIST,0 {}
+			#../Nuclear_GasCore_LH2/MODEL_MULTI_SHURIKEN_PERSIST,1 {}
 		}
 	}
 	


### PR DESCRIPTION
RealPlume-Stock version 1.5 changed the names of the effects that it applies to the MissingHistory "Candle" and "Beacon" engines, which resurrected bug #74 since the LH2NTR patch was once again trying to copy from effect nodes that didn't exist.  I've updated the patch to refer to the new effect names.