### PR TITLE
Fix netkan syntax error

### DIFF
--- a/CKAN/KerbalAtomics.netkan
+++ b/CKAN/KerbalAtomics.netkan
@@ -14,7 +14,7 @@
         { "name" : "B9PartSwitch" },
         { "name" : "CommunityResourcePack" },
         { "name" : "DeployableEngines" },
-        { "name" : "ModuleManager" }
+        { "name" : "ModuleManager" },
         { "any_of": [
             { "name": "CryoTanks" },
             { "name": "KerbalAtomics-NTRsUseLF" }


### PR DESCRIPTION
Just sighted in the CKAN Discord notifications channel:

> New inflation error for KerbalAtomics: After parsing a value an unexpected character was encountered: {. Path 'depends[3]', line 18, position 8.

The netkan file is missing a comma between dependencies.

This PR adds the comma.